### PR TITLE
Fix CPP Header parsing to return the right includeDir for a header within the same directory

### DIFF
--- a/cppfileparser.py
+++ b/cppfileparser.py
@@ -233,7 +233,7 @@ def _findCPPIncludeForFileSameDir(
 
     found = True
     logging.debug(
-        f"Found {file} in the same directory as the looked file generated {generated}"
+        f"Found {file} in the same directory as the looked file, generated ?: {generated}"
     )
     # We need a way of dealing with path with ..
     full_file_name = resolvePath(full_file_name)


### PR DESCRIPTION
Now that we are using includeDir instead of -I we need to return the
base folders where the header indicated in the include can be found.
That is to say that if we found the header "foo/bar.h" as included from
tata.cc in "bindings/c" we need to return "bindings/c" as an includeDir
so that the file could be found when the target is used in another
project.
